### PR TITLE
[BUGFIX] Ensure `_data.jsx` gets overwritten instead of appending

### DIFF
--- a/ge_releaser/cmd/prep.py
+++ b/ge_releaser/cmd/prep.py
@@ -92,10 +92,11 @@ def _update_docs_component(last_version: str, release_version: str) -> None:
     }
     ```
     """
-    with open(GxFile.DOCS_DATA_COMPONENT, "r+") as f:
+    with open(GxFile.DOCS_DATA_COMPONENT) as f:
         contents = f.read()
-        contents = contents.replace(last_version, release_version)
-        f.write(contents)
+    updated_contents = contents.replace(last_version, release_version)
+    with open(GxFile.DOCS_DATA_COMPONENT, "w") as f:
+        f.write(updated_contents)
 
 
 def _update_changelogs(


### PR DESCRIPTION
Faulty logic in `ge_releaser prep` causes an appended object (instead of overwriting the values as expected)
