### PR TITLE
[MAINTENANCE] Add warning that other files will also be committed

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ Make sure to ask the team about any necessary PR's that might need to go in befo
 curl -s https://api.github.com/repos/great-expectations/great_expectations/pulls | jq '.[] | select(.auto_merge.merge_method == "squash") | {title: .title, author: .user.login, date: .created_at, link: .html_url}'
 ```
 #### prep
+
+NOTE: While running the prep stage any untracked files will be committed and pushed to the repo. Please make sure you have a clean repo before running this command! Including any credentials e.g. GCP credentials.
+
 Run `ge_releaser prep`.
 ![prep](./assets/prep.png)
 - This will generate changelogs, update relevant files, and draft a PR titled `[RELEASE] <RELEASE_NUMBER>`.


### PR DESCRIPTION
When running the prep stage, other untracked files are committed as well. This PR adds another note to remind the releaser of this fact and to start with a clean repo.