### PR TITLE
[BUGFIX] `FILES_TO_COMMIT` correctly uses list comprehnesion to stage files

### DIFF
--- a/ge_releaser/git.py
+++ b/ge_releaser/git.py
@@ -46,7 +46,7 @@ class GitService:
             raise ValueError("There are untracked files. Please make sure to run this step with a clean repo.")
 
     def stage_all_and_commit(self, message: str) -> None:
-        self._git.git.add(FILES_TO_COMMIT)
+        self._git.git.add([(file_class.name) for file_class in FILES_TO_COMMIT]) 
         self._git.git.commit("-m", message, "--no-verify")
 
     def get_release_timestamp(self, version: str) -> dt.datetime:


### PR DESCRIPTION
Was running into the following error when using `ge_releaser prep` command. Bugfix to use list-comprehension

```
(supercon_ge) ➜  great_expectations git:(develop) ge_releaser prep                        

[prep]
 * Created a release branch (1/7)
 * Updated deployment version file (2/7)
 * Updated version in docs data component (3/7)
 * Updated version in docs version dropdown (4/7)
 * Updated changelogs (5/7)
  cmdline: git add GxFile.CHANGELOG_MD GxFile.DOCS_DATA_COMPONENT GxFile.DOCS_CONFIG GxFile.CHANGELOG_RST GxFile.DEPLOYMENT_VERSION
  stderr: 'fatal: pathspec 'GxFile.CHANGELOG_MD' did not match any files'
```