### PR TITLE
Add `GE_RELEASE_TRUNK` env var override

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,3 +145,8 @@ Specifically:
 - Send a draft message (to be reviewed by the team) to `#topic-great_expectations`, with the message that will be sent in the community Slack.
 - Send the reviewed meesage to the community Slack channel `#announcements`.
 - Request emoji signal boosting from the team in private Slack channel `#topic-great_expectations`.
+
+#### Override the default trunk value
+
+If doing an pre-v1 bugfix you may need to change the trunk value to something other than `develop`.
+`ge_releaser` will check for an environment variable called `GE_RELEASE_TRUNK` and use this if it is set instead of `develop`.

--- a/ge_releaser/utils.py
+++ b/ge_releaser/utils.py
@@ -10,6 +10,7 @@ from ge_releaser.constants import (
     RELEASER_LOCAL_VERSION,
     RELEASER_REMOTE_VERSION,
     REMOTE,
+    PRE_V1_TRUNK,
     TRUNK,
     GxFile,
 )
@@ -49,13 +50,20 @@ def _get_latest_version() -> str:
 
 def setup(ctx: click.Context) -> None:
     token: Optional[str] = os.environ.get("GITHUB_TOKEN")
+
     assert token is not None, "Must set GITHUB_TOKEN environment variable!"
+
+    trunk_override: Optional[str] = os.environ.get("GX_RELEASE_TRUNK")
+    if trunk_override and trunk_override != TRUNK:
+        input(
+            f"WARNING: GX_RELEASE_TRUNK is set to {trunk_override}. Press enter to continue. CTRL+C to exit."
+        )
 
     check_if_in_gx_root()
     check_if_using_latest_version()
 
     git = GitService(
-        github_token=token, repo_name=GITHUB_REPO, trunk=TRUNK, remote=REMOTE
+        github_token=token, repo_name=GITHUB_REPO, trunk=trunk_override or TRUNK, remote=REMOTE
     )
     git.verify_no_untracked_files()
     ctx.obj = git


### PR DESCRIPTION
Make it possible to override the default `develop` trunk used by ge_releaser by setting an environment variable.