### PR TITLE
Fix changelog usage in `0.18.x` release

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,8 @@ Specifically:
 If doing an pre-v1 bugfix you may need to change the trunk value to something other than `develop`.
 `ge_releaser` will check for an environment variable called `GE_RELEASE_TRUNK` and use this if it is set instead of `develop`.
 
+Example: `export GE_RELEASE_TRUNK=0.18.x`
+
 
 
 #### Yanking Releases

--- a/ge_releaser/cmd/prep.py
+++ b/ge_releaser/cmd/prep.py
@@ -123,9 +123,10 @@ def _update_changelogs(
 
     changelog_entry = ChangelogEntry(relevant_prs)
 
-    changelog_entry.write(GxFile.CHANGELOG_MD_V1, last_version, release_version)
     if git.trunk_is_0ver:
         changelog_entry.write(GxFile.CHANGELOG_MD_V0, last_version, release_version)
+    else:
+        changelog_entry.write(GxFile.CHANGELOG_MD_V1, last_version, release_version)
     changelog_entry.write(GxFile.CHANGELOG_RST, last_version, release_version)
 
 

--- a/ge_releaser/cmd/prep.py
+++ b/ge_releaser/cmd/prep.py
@@ -123,7 +123,9 @@ def _update_changelogs(
 
     changelog_entry = ChangelogEntry(relevant_prs)
 
-    changelog_entry.write(GxFile.CHANGELOG_MD, last_version, release_version)
+    changelog_entry.write(GxFile.CHANGELOG_MD_V1, last_version, release_version)
+    if git.trunk_is_0ver:
+        changelog_entry.write(GxFile.CHANGELOG_MD_V0, last_version, release_version)
     changelog_entry.write(GxFile.CHANGELOG_RST, last_version, release_version)
 
 

--- a/ge_releaser/cmd/publish.py
+++ b/ge_releaser/cmd/publish.py
@@ -32,7 +32,7 @@ def _create_release(git: GitService, release_version: str, draft: bool) -> None:
 
 
 def _gather_release_notes(release_version: str) -> List[str]:
-    with open(GxFile.CHANGELOG_MD, "r") as f:
+    with open(GxFile.CHANGELOG_MD_V1, "r") as f:
         contents: List[str] = f.readlines()
 
     start: int = 0

--- a/ge_releaser/cmd/publish.py
+++ b/ge_releaser/cmd/publish.py
@@ -1,3 +1,4 @@
+import pathlib
 from typing import List, cast
 
 import click
@@ -26,13 +27,14 @@ def _parse_deployment_version_file() -> str:
 
 
 def _create_release(git: GitService, release_version: str, draft: bool) -> None:
-    release_notes = _gather_release_notes(release_version)
+    changelog_path = GxFile.CHANGELOG_MD_V0 if git.trunk_is_0ver else GxFile.CHANGELOG_MD_V1
+    release_notes = _gather_release_notes(release_version, pathlib.Path(changelog_path))
     message = "".join(line for line in release_notes)
     git.create_release(version=release_version, message=message, draft=draft)
 
 
-def _gather_release_notes(release_version: str) -> List[str]:
-    with open(GxFile.CHANGELOG_MD_V1, "r") as f:
+def _gather_release_notes(release_version: str, changelog_path: pathlib.Path) -> List[str]:
+    with open(changelog_path, "r") as f:
         contents: List[str] = f.readlines()
 
     start: int = 0

--- a/ge_releaser/cmd/tag.py
+++ b/ge_releaser/cmd/tag.py
@@ -40,7 +40,6 @@ def _check_version_validity(version_number: str, is_stable_release: bool) -> Non
 
 def _tag_release_commit(git: GitService, commit: str, release_version: str) -> None:
     if not git.check_if_commit_is_part_of_trunk(commit):
-        # TODO: make git._trunk public
         raise ValueError(
             f"Selected commit {commit} is not a part of the '{git.trunk}' branch!"
         )

--- a/ge_releaser/constants.py
+++ b/ge_releaser/constants.py
@@ -22,7 +22,8 @@ class GxURL(str, enum.Enum):
 
 class GxFile(str, enum.Enum):
     DEPLOYMENT_VERSION = "great_expectations/deployment_version"
-    CHANGELOG_MD = "docs/docusaurus/docs/oss/changelog.md"
+    CHANGELOG_MD_V1 = "docs/docusaurus/docs/oss/changelog.md"
+    CHANGELOG_MD_V0 = "docs/docusaurus/docs/changelog.md"
     CHANGELOG_RST = "docs_rtd/changelog.rst"
     TEAMS = ".github/teams.yml"
     DOCS_DATA_COMPONENT = "docs/docusaurus/docs/components/_data.jsx"

--- a/ge_releaser/constants.py
+++ b/ge_releaser/constants.py
@@ -31,7 +31,8 @@ class GxFile(str, enum.Enum):
 
 
 FILES_TO_COMMIT = (
-    GxFile.CHANGELOG_MD,
+    GxFile.CHANGELOG_MD_V1,
+    GxFile.CHANGELOG_MD_V0,
     GxFile.DOCS_DATA_COMPONENT,
     GxFile.DOCS_CONFIG,
     GxFile.CHANGELOG_RST,

--- a/ge_releaser/git.py
+++ b/ge_releaser/git.py
@@ -28,6 +28,13 @@ class GitService:
     def trunk(self) -> str:
         return self._trunk
 
+    @property
+    def trunk_is_0ver(self) -> bool:
+        """
+        Returns True if the trunk branch is named for a 0.x release.
+        """
+        return self._trunk.startswith("0.")
+
     def get_tags(self) -> List[git.Tag]:
         return sorted(self._git.tags, key=lambda t: t.commit.committed_datetime)
 


### PR DESCRIPTION
These changes were needed for the `0.18.11` release
- https://github.com/great-expectations/great_expectations/pull/9625