### PR TITLE
Fix changelog path

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ export GE_RELEASE_TRUNK=0.18.x
 
 - Make sure to ask the team about any necessary PR's that might need to go in before running this command.
 
-- Make sure to cordinate with #pod-zelda for the release of GX Agent. Releases of GX Agent will be on thursdays
+- Make sure to cordinate with #pod-zelda for the release of the GX Agent. Releases of the GX Agent will be on Thursdays.
 
 #### tag
 
@@ -89,7 +89,7 @@ ge_releaser tag --stable eb548b9b58bed229e601f2fe60c4767bcfca8c1d 0.18.8
 
 ![tag](./assets/tag.png)
 
-2. **IMPORTANT** - Wait until the [PyPi Deployment](https://github.com/great-expectations/great_expectations/deployments/pypi) finishes and version is published to the [PyPi page](https://pypi.org/project/great-expectations/#history)
+2. **IMPORTANT** - Wait until the [PyPi Deployment](https://github.com/great-expectations/great_expectations/deployments/pypi) finishes and version is published to the [PyPi page](https://pypi.org/project/great-expectations/#history). Now is a good time to start a thread in #gx-platform-release about the release. You can post updates to this thread as the release progresses.
 
 
 ```bash

--- a/ge_releaser/cmd/publish.py
+++ b/ge_releaser/cmd/publish.py
@@ -30,7 +30,7 @@ def _create_release(git: GitService, release_version: str, draft: bool) -> None:
     changelog_path = (
         GxFile.CHANGELOG_MD_V0 if git.trunk_is_0ver else GxFile.CHANGELOG_MD_V1
     )
-    release_notes = _gather_release_notes(release_version, pathlib.Path(changelog_path))
+    release_notes = _gather_release_notes(release_version, pathlib.Path(changelog_path.value))
     message = "".join(line for line in release_notes)
     git.create_release(version=release_version, message=message, draft=draft)
 

--- a/ge_releaser/cmd/tag.py
+++ b/ge_releaser/cmd/tag.py
@@ -50,7 +50,8 @@ def _tag_release_commit(git: GitService, commit: str, release_version: str) -> N
 def _print_next_steps(version_number: str) -> None:
     tag_url = os.path.join(GxURL.RELEASES, "tag", version_number)
 
-    msg = "Please wait for the build process and PyPI publishing to complete before moving to the `prep` cmd."
+    msg = ("Please start a thread in #gx-platform-release about the release and update the thread as the release progresses. "
+           "Make sure to wait for the build process and PyPI publishing to complete before moving to the `prep` cmd.")
 
     click.secho(f"\n{msg}", fg="green")
     click.echo(f"Link to tag: {tag_url}")


### PR DESCRIPTION
Issue: 

`No such file or directory: 'GxFile.CHANGELOG_MD_V0` error when running `ge_releaser publish`--actual path wasn't being used

Fix:

Use `changelog_path.value` for `pathlib.Path()`


Also made updates to README and `tag` command to remind releasers to post to `#gx-platform-release` when releasing per convo [here](https://greatexpectationslabs.slack.com/archives/C05R8RE43CL/p1714416713803129?thread_ts=1714407768.041559&cid=C05R8RE43CL).