### PR TITLE
Update to python 3.11

### DIFF
--- a/ge_releaser/constants.py
+++ b/ge_releaser/constants.py
@@ -1,5 +1,5 @@
-import enum
 import pathlib
+from enum import StrEnum
 
 RELEASER_LOCAL_VERSION = str(
     pathlib.Path(__file__).parent.parent.joinpath("VERSION").resolve()
@@ -12,7 +12,7 @@ REMOTE = "origin"
 GITHUB_REPO = "great-expectations/great_expectations"
 
 
-class GxURL(str, enum.Enum):
+class GxURL(StrEnum):
     GITHUB_ACTIONS_BUILD = (
         f"https://github.com/{GITHUB_REPO}/actions/workflows/ci.yml?query=event%3Apush"
     )
@@ -22,7 +22,7 @@ class GxURL(str, enum.Enum):
     PULL_REQUESTS = f"{BASE_URL}/pull"
 
 
-class GxFile(str, enum.Enum):
+class GxFile(StrEnum):
     DEPLOYMENT_VERSION = "great_expectations/deployment_version"
     CHANGELOG_MD_V1 = "docs/docusaurus/docs/oss/changelog.md"
     CHANGELOG_MD_V0 = "docs/docusaurus/docs/changelog.md"

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setuptools.setup(
     name="ge_releaser",
     version=get_version(),
     install_requires=get_requirements(),
-    python_requires=">=3.8",
+    python_requires=">=3.11",
     entry_points="""
       [console_scripts]
       ge_releaser=ge_releaser.cli:cli


### PR DESCRIPTION
In python 3.11 and above our string enums such as `GxURL(str, enum.Enum)` would start printing out as the enum value instead of the string value. For example, instead of links, we will see:
```
Link to Github Actions build: GxURL.GITHUB_ACTIONS_BUILD
Link to PyPI page: GxURL.PYPI_PAGE
```
This is especially annoying for the PR links in the release PR. In 3.11 a new enum type exists `StrEnum` which will print out correctly and is the new way to make string enums.



